### PR TITLE
fix: Quick naming fix

### DIFF
--- a/src/catppuccin-frappe/metadata.desktop
+++ b/src/catppuccin-frappe/metadata.desktop
@@ -1,5 +1,5 @@
 [SddmGreeterTheme]
-Name=Catppuccin Mocha
+Name=Catppuccin Frappe
 Description=Soothing pastel theme for SDDM
 Type=sddm-theme
 Version=2.0

--- a/src/catppuccin-latte/metadata.desktop
+++ b/src/catppuccin-latte/metadata.desktop
@@ -1,5 +1,5 @@
 [SddmGreeterTheme]
-Name=Catppuccin Mocha
+Name=Catppuccin Latte
 Description=Soothing pastel theme for SDDM
 Type=sddm-theme
 Version=2.0

--- a/src/catppuccin-macchiato/metadata.desktop
+++ b/src/catppuccin-macchiato/metadata.desktop
@@ -1,5 +1,5 @@
 [SddmGreeterTheme]
-Name=Catppuccin Mocha
+Name=Catppuccin Macchiato
 Description=Soothing pastel theme for SDDM
 Type=sddm-theme
 Version=2.0

--- a/src/catppuccin-old/metadata.desktop
+++ b/src/catppuccin-old/metadata.desktop
@@ -1,5 +1,5 @@
 [SddmGreeterTheme]
-Name=Catppuccin
+Name=Catppuccin Old
 Description=The hottest theme for SDDM
 Type=sddm-theme
 Version=1.0


### PR DESCRIPTION
A very quick and dirty fix for the naming part of issue #4, simply edited the `metadata.desktop` files to match their folder names.

Images still all show the Mocha version.