### PR TITLE
Add config option for showing last letter of password

### DIFF
--- a/src/catppuccin-frappe/Components/PasswordField.qml
+++ b/src/catppuccin-frappe/Components/PasswordField.qml
@@ -8,7 +8,7 @@ TextField {
   placeholderText: "Password"
   echoMode: TextInput.Password
   passwordCharacter: "•"
-  passwordMaskDelay: 1000
+  passwordMaskDelay: config.PasswordShowLastLetter
   selectionColor: config.overlay0
   renderType: Text.NativeRendering
   font.family: config.Font

--- a/src/catppuccin-frappe/theme.conf
+++ b/src/catppuccin-frappe/theme.conf
@@ -6,6 +6,10 @@ CustomBackground="false"
 LoginBackground="false"
 Background="backgrounds/wall.jpg"
 
+# Uncomment this option to show the last letter of the password
+# for the number of milliseconds specified
+# PasswordShowLastLetter=1000
+
 # DON'T CHANGE THESE
 rosewater = "#f2d5cf"
 flamingo  = "#eebebe"

--- a/src/catppuccin-latte/Components/PasswordField.qml
+++ b/src/catppuccin-latte/Components/PasswordField.qml
@@ -8,7 +8,7 @@ TextField {
   placeholderText: "Password"
   echoMode: TextInput.Password
   passwordCharacter: "•"
-  passwordMaskDelay: 1000
+  passwordMaskDelay: config.PasswordShowLastLetter
   selectionColor: config.overlay0
   renderType: Text.NativeRendering
   font.family: config.Font

--- a/src/catppuccin-latte/theme.conf
+++ b/src/catppuccin-latte/theme.conf
@@ -6,6 +6,10 @@ CustomBackground="false"
 LoginBackground="false"
 Background="backgrounds/wall.jpg"
 
+# Uncomment this option to show the last letter of the password
+# for the number of milliseconds specified
+# PasswordShowLastLetter=1000
+
 # DON'T CHANGE THESE
 rosewater = "#dc8a78"
 flamingo  = "#dd7878"

--- a/src/catppuccin-macchiato/Components/PasswordField.qml
+++ b/src/catppuccin-macchiato/Components/PasswordField.qml
@@ -8,7 +8,7 @@ TextField {
   placeholderText: "Password"
   echoMode: TextInput.Password
   passwordCharacter: "•"
-  passwordMaskDelay: 1000
+  passwordMaskDelay: config.PasswordShowLastLetter
   selectionColor: config.overlay0
   renderType: Text.NativeRendering
   font.family: config.Font

--- a/src/catppuccin-macchiato/theme.conf
+++ b/src/catppuccin-macchiato/theme.conf
@@ -6,6 +6,10 @@ CustomBackground="false"
 LoginBackground="false"
 Background="backgrounds/wall.jpg"
 
+# Uncomment this option to show the last letter of the password
+# for the number of milliseconds specified
+# PasswordShowLastLetter=1000
+
 # DON'T CHANGE THESE
 rosewater = "#f4dbd6"
 flamingo  = "#f0c6c6"

--- a/src/catppuccin-mocha/Components/PasswordField.qml
+++ b/src/catppuccin-mocha/Components/PasswordField.qml
@@ -8,7 +8,7 @@ TextField {
   placeholderText: "Password"
   echoMode: TextInput.Password
   passwordCharacter: "•"
-  passwordMaskDelay: 1000
+  passwordMaskDelay: config.PasswordShowLastLetter
   selectionColor: config.overlay0
   renderType: Text.NativeRendering
   font.family: config.Font

--- a/src/catppuccin-mocha/theme.conf
+++ b/src/catppuccin-mocha/theme.conf
@@ -6,6 +6,10 @@ CustomBackground="false"
 LoginBackground="false"
 Background="backgrounds/wall.jpg"
 
+# Uncomment this option to show the last letter of the password
+# for the number of milliseconds specified
+# PasswordShowLastLetter=1000
+
 # DON'T CHANGE THESE
 rosewater = "#f5e0dc"
 flamingo  = "#f2cdcd"


### PR DESCRIPTION
The current default behavior of showing the last letter of the password is very insecure. On desktop, standard behavior is not having the preview.

Supersedes #14  with a configurable option in case users prefer the current behavior.

Changed the default to the safer option (no show).