### PR TITLE
Fix qt6 compatibility

### DIFF
--- a/src/catppuccin-frappe/metadata.desktop
+++ b/src/catppuccin-frappe/metadata.desktop
@@ -11,3 +11,4 @@ TranslationsDirectory=translations
 Theme-Id=Catppuccin
 Theme-API=2.0
 License=MIT
+QtVersion=6

--- a/src/catppuccin-latte/metadata.desktop
+++ b/src/catppuccin-latte/metadata.desktop
@@ -11,3 +11,4 @@ TranslationsDirectory=translations
 Theme-Id=Catppuccin
 Theme-API=2.0
 License=MIT
+QtVersion=6

--- a/src/catppuccin-macchiato/metadata.desktop
+++ b/src/catppuccin-macchiato/metadata.desktop
@@ -11,3 +11,4 @@ TranslationsDirectory=translations
 Theme-Id=Catppuccin
 Theme-API=2.0
 License=MIT
+QtVersion=6

--- a/src/catppuccin-mocha/metadata.desktop
+++ b/src/catppuccin-mocha/metadata.desktop
@@ -11,3 +11,4 @@ TranslationsDirectory=translations
 Theme-Id=Catppuccin
 Theme-API=2.0
 License=MIT
+QtVersion=6


### PR DESCRIPTION
The theme is basically compatible with SDDM using Qt6, but for some operating systems (like NixOS) it doesn't work properly because it doesn't have the correct metadata information. 

This PR aims to fix this.