### PR TITLE
fix: doesn't work if plasma6 isn't used in nixos #30

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Then set it as the theme in the sddm configuration, change the suffix to the fla
 displayManager.sddm = {
   enable = true;
   theme = "catppuccin-mocha";
+  package = pkgs.kdePackages.sddm;
 };
 ```
 


### PR DESCRIPTION
The catppuccin theme wouldn't be applied to sddm if you didn't include this like or modify metadata.desktop file.