### PR TITLE
Updated to Qt6.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,25 +53,25 @@ Current=catppuccin-flavour
 ### Arch Based OS
 
 ```bash
-pacman -Syu qt6-svg qt6-declarative qt5-quickcontrols2
+pacman -Syu qt6-svg qt6-declarative
 ```
 
 ### Debian Based OS
 
 ```bash
-apt install --no-install-recommends qml-module-qtquick-layouts qml-module-qtquick-controls2 libqt6svg6
+apt install qt6-svg qt6-declarative
 ```
 
 ### RPM Based OS
 
 ```bash
-dnf install qt6-qtquickcontrols2 qt6-qtsvg
+dnf install qt6-svg qt6-declarative
 ```
 
 ### Solus OS
 
 ```bash
-eopkg install qt6-quickcontrols2 qt6-svg
+eopkg install qt6-svg qt6-declarative
 ```
 
 ### NixOS

--- a/src/Components/Clock.qml
+++ b/src/Components/Clock.qml
@@ -1,4 +1,4 @@
-import QtQuick 2.15
+import QtQuick 6.8
 import SddmComponents 2.0
 
 Clock {

--- a/src/Components/LoginPanel.qml
+++ b/src/Components/LoginPanel.qml
@@ -1,6 +1,6 @@
-import QtQuick 2.15
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.15
+import QtQuick 6.8
+import QtQuick.Window 6.8
+import QtQuick.Controls 6.8
 
 Item {
   property var user: userField.text
@@ -8,6 +8,7 @@ Item {
   property var session: sessionPanel.session
   property var inputHeight: Screen.height * 0.032
   property var inputWidth: Screen.width * 0.16
+
   Rectangle {
     id: loginBackground
     anchors {
@@ -20,6 +21,7 @@ Item {
     visible: config.LoginBackground == "true" ? true : false
     color: config.mantle
   }
+
   Column {
     spacing: 8
     anchors {
@@ -37,6 +39,7 @@ Item {
     }
     z: 5
   }
+
   Column {
     spacing: 8
     anchors {
@@ -48,6 +51,7 @@ Item {
     }
     z: 5
   }
+
   Column {
     spacing: 8
     z: 5
@@ -67,6 +71,7 @@ Item {
       width: parent.width
       onAccepted: loginButton.clicked()
     }
+
     Button {
       id: loginButton
       height: inputHeight
@@ -91,6 +96,7 @@ Item {
         color: config.sapphire
         radius: 3
       }
+
       states: [
         State {
           name: "pressed"
@@ -98,9 +104,6 @@ Item {
           PropertyChanges {
             target: buttonBackground
             color: config.teal
-          }
-          PropertyChanges {
-            target: buttonText
           }
         },
         State {
@@ -110,9 +113,6 @@ Item {
             target: buttonBackground
             color: config.teal
           }
-          PropertyChanges {
-            target: buttonText
-          }
         },
         State {
           name: "enabled"
@@ -120,22 +120,22 @@ Item {
           PropertyChanges {
             target: buttonBackground
           }
-          PropertyChanges {
-            target: buttonText
-          }
         }
       ]
+
       transitions: Transition {
         PropertyAnimation {
-          properties: "color"
+          property: "color"
           duration: 300
         }
       }
+
       onClicked: {
         sddm.login(user, password, session)
       }
     }
   }
+
   Connections {
     target: sddm
 

--- a/src/Components/PasswordField.qml
+++ b/src/Components/PasswordField.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick 6.8
+import QtQuick.Controls 6.8
 
 TextField {
   id: passwordField
@@ -16,11 +16,13 @@ TextField {
   font.bold: true
   color: config.text
   horizontalAlignment: TextInput.AlignHCenter
+
   background: Rectangle {
     id: passFieldBackground
     radius: 3
     color: config.surface0
   }
+
   states: [
     State {
       name: "focused"
@@ -39,9 +41,10 @@ TextField {
       }
     }
   ]
+
   transitions: Transition {
     PropertyAnimation {
-      properties: "color"
+      property: "color"
       duration: 300
     }
   }

--- a/src/Components/PowerButton.qml
+++ b/src/Components/PowerButton.qml
@@ -1,25 +1,27 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick 6.8
+import QtQuick.Controls 6.8
 
 Item {
   implicitHeight: powerButton.height
   implicitWidth: powerButton.width
+
   Button {
     id: powerButton
     height: inputHeight
     width: inputHeight
     hoverEnabled: true
-    icon {
-      source: Qt.resolvedUrl("../icons/power.svg")
-      height: height
-      width: width
-      color: config.crust
-    }
+
+    icon.source: Qt.resolvedUrl("../icons/power.svg")
+    icon.height: height
+    icon.width: width
+    icon.color: config.crust
+
     background: Rectangle {
       id: powerButtonBackground
       radius: 3
       color: config.red
     }
+
     states: [
       State {
         name: "hovered"
@@ -30,12 +32,14 @@ Item {
         }
       }
     ]
+
     transitions: Transition {
       PropertyAnimation {
-        properties: "color"
+        property: "color"
         duration: 300
       }
     }
+
     onClicked: sddm.powerOff()
   }
 }

--- a/src/Components/RebootButton.qml
+++ b/src/Components/RebootButton.qml
@@ -1,25 +1,27 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick 6.8
+import QtQuick.Controls 6.8
 
 Item {
   implicitHeight: rebootButton.height
   implicitWidth: rebootButton.width
+
   Button {
     id: rebootButton
     height: inputHeight
     width: inputHeight
     hoverEnabled: true
-    icon {
-      source: Qt.resolvedUrl("../icons/reboot.svg")
-      height: height
-      width: width
-      color: config.crust
-    }
+
+    icon.source: Qt.resolvedUrl("../icons/reboot.svg")
+    icon.height: height
+    icon.width: width
+    icon.color: config.crust
+
     background: Rectangle {
       id: rebootButtonBackground
       radius: 3
       color: config.red
     }
+
     states: [
       State {
         name: "hovered"
@@ -30,12 +32,14 @@ Item {
         }
       }
     ]
+
     transitions: Transition {
       PropertyAnimation {
-        properties: "color"
+        property: "color"
         duration: 300
       }
     }
+
     onClicked: sddm.reboot()
   }
 }

--- a/src/Components/SessionPanel.qml
+++ b/src/Components/SessionPanel.qml
@@ -1,19 +1,22 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQml.Models 2.15
+import QtQuick 6.8
+import QtQuick.Controls 6.8
+import QtQml.Models 6.8
 
 Item {
   property var session: sessionList.currentIndex
   implicitHeight: sessionButton.height
   implicitWidth: sessionButton.width
+
   DelegateModel {
     id: sessionWrapper
     model: sessionModel
+
     delegate: ItemDelegate {
       id: sessionEntry
       height: inputHeight
       width: parent.width
       highlighted: sessionList.currentIndex == index
+      
       contentItem: Text {
         renderType: Text.NativeRendering
         font.family: config.Font
@@ -24,11 +27,13 @@ Item {
         color: config.text
         text: name
       }
+
       background: Rectangle {
         id: sessionEntryBackground
         color: config.surface1
         radius: 3
       }
+
       states: [
         State {
           name: "hovered"
@@ -39,12 +44,14 @@ Item {
           }
         }
       ]
+
       transitions: Transition {
         PropertyAnimation {
           property: "color"
           duration: 300
         }
       }
+
       MouseArea {
         anchors.fill: parent
         onClicked: {
@@ -54,22 +61,24 @@ Item {
       }
     }
   }
+
   Button {
     id: sessionButton
     height: inputHeight
     width: inputHeight
     hoverEnabled: true
-    icon {
-      source: Qt.resolvedUrl("../icons/settings.svg")
-      height: height
-      width: width
-      color: config.text
-    }
+
+    icon.source: Qt.resolvedUrl("../icons/settings.svg")
+    icon.height: height
+    icon.width: width
+    icon.color: config.text
+
     background: Rectangle {
       id: sessionButtonBackground
       color: config.surface0
       radius: 3
     }
+
     states: [
       State {
         name: "pressed"
@@ -96,27 +105,32 @@ Item {
         }
       }
     ]
+
     transitions: Transition {
       PropertyAnimation {
         properties: "color"
         duration: 150
       }
     }
+
     onClicked: {
       sessionPopup.visible ? sessionPopup.close() : sessionPopup.open()
       sessionButton.state = "pressed"
     }
   }
+
   Popup {
     id: sessionPopup
     width: inputWidth + padding * 2
     x: (sessionButton.width + sessionList.spacing) * -7.6
     y: -(contentHeight + padding * 2) + sessionButton.height
     padding: inputHeight / 10
+
     background: Rectangle {
       radius: 5.4
       color: config.surface0
     }
+
     contentItem: ListView {
       id: sessionList
       implicitHeight: contentHeight
@@ -125,6 +139,7 @@ Item {
       currentIndex: sessionModel.lastIndex
       clip: true
     }
+
     enter: Transition {
       ParallelAnimation {
         NumberAnimation {
@@ -143,6 +158,7 @@ Item {
         }
       }
     }
+
     exit: Transition {
       NumberAnimation {
         property: "opacity"

--- a/src/Components/SleepButton.qml
+++ b/src/Components/SleepButton.qml
@@ -1,25 +1,27 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick 6.8
+import QtQuick.Controls 6.8
 
 Item {
   implicitHeight: sleepButton.height
   implicitWidth: sleepButton.width
+
   Button {
     id: sleepButton
     height: inputHeight
     width: inputHeight
     hoverEnabled: true
-    icon {
-      source: Qt.resolvedUrl("../icons/sleep.svg")
-      height: height
-      width: width
-      color: config.crust
-    }
+
+    icon.source: Qt.resolvedUrl("../icons/sleep.svg")
+    icon.height: height
+    icon.width: width
+    icon.color: config.crust
+
     background: Rectangle {
       id: sleepButtonBg
       color: config.red
       radius: 3
     }
+
     states: [
       State {
         name: "hovered"
@@ -30,12 +32,14 @@ Item {
         }
       }
     ]
+
     transitions: Transition {
       PropertyAnimation {
         properties: "color"
         duration: 300
       }
     }
+
     onClicked: sddm.suspend()
   }
 }

--- a/src/Components/UserField.qml
+++ b/src/Components/UserField.qml
@@ -1,5 +1,5 @@
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick 6.8
+import QtQuick.Controls 6.8
 
 TextField {
   id: userField
@@ -9,20 +9,20 @@ TextField {
   echoMode: TextInput.Normal
   selectionColor: config.overlay0
   renderType: Text.NativeRendering
-  font {
-    family: config.Font
-    pointSize: config.FontSize
-    bold: true
-  }
+  font.family: config.Font
+  font.pointSize: config.FontSize
+  font.bold: true
   color: config.text
   horizontalAlignment: Text.AlignHCenter
   placeholderText: "Username"
   text: userModel.lastUser
+
   background: Rectangle {
     id: userFieldBackground
     color: config.surface0
     radius: 3
   }
+
   states: [
     State {
       name: "focused"
@@ -41,6 +41,7 @@ TextField {
       }
     }
   ]
+
   transitions: Transition {
     PropertyAnimation {
       properties: "color"

--- a/src/Main.qml
+++ b/src/Main.qml
@@ -1,12 +1,13 @@
-import QtQuick 2.15
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.15
+import QtQuick 6.8
+import QtQuick.Window 6.8
+import QtQuick.Controls 6.8
 import "Components"
 
 Item {
   id: root
   height: Screen.height
   width: Screen.width
+
   Rectangle {
     id: background
     anchors.fill: parent
@@ -15,6 +16,7 @@ Item {
     z: 0
     color: config.base
   }
+
   Image {
     id: backgroundImage
     anchors.fill: parent
@@ -29,6 +31,7 @@ Item {
     mipmap: true
     clip: true
   }
+
   Item {
     id: mainPanel
     z: 3
@@ -36,10 +39,12 @@ Item {
       fill: parent
       margins: 50
     }
+
     Clock {
       id: time
       visible: config.ClockEnabled == "true" ? true : false
     }
+
     LoginPanel {
       id: loginPanel
       anchors.fill: parent

--- a/src/metadata.desktop
+++ b/src/metadata.desktop
@@ -11,4 +11,4 @@ TranslationsDirectory=translations
 Theme-Id=Catppuccin
 Theme-API=2.0
 License=MIT
-QtVersion=6
+QtVersion=6.8


### PR DESCRIPTION
Updated the qml files to comply with changes in QtQuick 6.8.

Tested and working on my Arch machine

Updated the README to reflect the updated dependencies - namely the removal of qt5-quickcontrols2, as it is now just quickcontrols as of qt6 and part of the qt6-base.
(I haven't fully cross-referenced the repos of all other distros for package names/versions, so there may be slight differences needing updating in that regard.)