### PR TITLE
fix(publishing): allows bsdtar to unzip with parent dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 3. Unzip the file and move the resulting directory to `/usr/share/sddm/themes/`. E.g. to copy `catppuccin-mocha-mauve`:
 
     ```bash
-    sudo mv -v catppuccin-mocha-mauve-sddm /usr/share/sddm/themes/catppuccin-mocha-mauve
+    sudo mv -v catppuccin-mocha-mauve /usr/share/sddm/themes
     ```
 
 4. Edit the `/etc/sddm.conf` file and change the theme to `catppuccin-<flavour>-<accent>`. For example, `catppuccin-mocha-mauve`.

--- a/justfile
+++ b/justfile
@@ -27,5 +27,5 @@ zip: build
   for dir in ./themes/*; do
     [ -e "$dir/theme.conf" ] || continue
     theme_name="$(basename "$dir")"
-    (cd "$dir" && zip -r "../../zips/${theme_name}-sddm" .)
+    (cd themes && zip -r "../zips/${theme_name}-sddm" "${theme_name}")
   done


### PR DESCRIPTION
Required for publishing to the AUR automatically in our catppuccin/aur-packages repository.

The PR was previously failing because unzipping via `bsdtar` didn't keep the name of the parent directory.